### PR TITLE
Add reset button and fix error in ObjInstanceStateList

### DIFF
--- a/src/js/components/Authenticating.jsx
+++ b/src/js/components/Authenticating.jsx
@@ -9,6 +9,11 @@ import Button from '@mui/material/Button'
 
 function Authenticating(props) {
 	const {i18n, t} = useTranslation()
+    const resetDefaultAuthChoice = () => {
+        localStorage.setItem("opensvc.authChoice", "")
+        window.location.reload()
+    }
+
 	return (
 		<Dialog
 			open={true}
@@ -26,6 +31,9 @@ function Authenticating(props) {
 				<Button onClick={() => location.reload()}>
 					{t("Reload")}
 				</Button>
+                <Button onClick={resetDefaultAuthChoice}>
+                    {t("Reset authentication method")}
+                </Button>
 			</DialogActions>
 		</Dialog>
 	)

--- a/src/js/components/ObjInstanceStateList.jsx
+++ b/src/js/components/ObjInstanceStateList.jsx
@@ -16,8 +16,16 @@ function ObjInstanceStateList(props) {
 	if (cstat.monitor === undefined) {
 		return null
 	}
-	var data = cstat.monitor.nodes[node].services.status[path]
-	return (
+    let nodeData = cstat.monitor.nodes[node]
+    if (nodeData === undefined) {
+        return null
+    }
+    let data = nodeData.services.status[path]
+    if (data === undefined) {
+        return null
+    }
+
+    return (
 		<List dense={true}>
 			<ObjAvailItem avail={data.avail} />
 			<MonitorStatusBadgeItem state={data.monitor.status} />


### PR DESCRIPTION
```markdown
### Description of Changes

This pull request includes the following changes:
1. **Reset Button for Default Authentication Choice**:
   - Added a button in the Authenticating dialog, allowing users to clear the `opensvc.authChoice` value stored in local storage.
   - The button reloads the page after resetting the choice to provide a smooth user experience.

2. **Fix `ObjInstanceStateList` Error**:
   - Corrected handling of `null` and `undefined` values in the `ObjInstanceStateList` component.
   - Refactored property access to ensure stability and prevent runtime errors related to undefined object properties.
```